### PR TITLE
fix: Images with no tags

### DIFF
--- a/vm/github.go
+++ b/vm/github.go
@@ -205,7 +205,7 @@ func getPackageVersions(client *github.Client, ct context.Context, organizationI
 	var packages []PackageVersion
 
 	for _, githubPackage := range githubPackages {
-		if githubPackage.Name != nil && *githubPackage.Name != "" {
+		if githubPackage.Name != nil && *githubPackage.Name != "" && len(githubPackage.Metadata.Container.Tags)!=0 {
 			packages = append(packages, PackageVersion{
 				Name:             githubPackage.Metadata.Container.Tags[0],
 				Id:               *githubPackage.ID,


### PR DESCRIPTION
[Issue](https://github.com/peacecwz/github-registry-docker-desktop-extension/issues/2) #2  - **Error after logging in while fetching packages**

After logging in packages are fetched and their name set as first tag, but tags list can be empty and causes runtime error. 